### PR TITLE
consul: set protocols meta to support wakucanary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,16 +27,14 @@ go_waku_dns4_domain_name: '{{ dns_entry }}'
 go_waku_extra_flags: []
 
 # Protocols
-go_waku_relay_enabled: true
-go_waku_store_enabled: false
+# Available: relay, store, filter, lightpush
+go_waku_protocols_enabled: ['relay']
 go_waku_store_nodes: []
 go_waku_store_persist_messages: false
 go_waku_store_capacity: 10000
 go_waku_store_duration: '168h' # 7 days
 go_waku_store_vacuum: false
-go_waku_filter_enabled: false
 go_waku_filter_nodes: []
-go_waku_lightpush_enabled: false
 go_waku_lightpush_nodes: []
 
 # DNS Discovery

--- a/tasks/consul.yml
+++ b/tasks/consul.yml
@@ -9,6 +9,7 @@
         tags: ['env:{{ env }}', 'stage:{{ stage }}', 'go', 'waku']
         meta:
           node_enode: '{{ go_waku_node_multiaddr | default("unknown") }}'
+          protocols: '{{ go_waku_protocols_enabled | join(",") }}'
         checks:
           - name: '{{ go_waku_service_name }}-health'
             type: 'tcp'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -40,9 +40,9 @@ services:
       --port={{ go_waku_libp2p_port }}
       --ext-ip={{ go_waku_public_address }}
       --dns4-domain-name={{ go_waku_dns4_domain_name }}
-      --relay={{ go_waku_relay_enabled | bool | to_json }}
-      --store={{ go_waku_store_enabled | bool | to_json }}
-{% if go_waku_store_enabled %}
+      --relay={{ 'true' if 'relay' in go_waku_protocols_enabled else 'false' }}
+{% if 'store' in go_waku_protocols_enabled %}
+      --store=true
       --store-message-db-url=sqlite3:///data/store.db
       --store-message-retention-capacity={{ go_waku_store_capacity }}
       --store-message-retention-time={{ go_waku_store_duration }}
@@ -50,18 +50,24 @@ services:
 {% for node in go_waku_store_nodes %}
       --store-node={{ node }}
 {% endfor %}
+{% else %}
+      --store=false
 {% endif %}
-      --filter={{ go_waku_filter_enabled | bool | to_json }}
-{% if go_waku_filter_enabled %}
+{% if 'filter' in go_waku_protocols_enabled %}
+      --filter=true
 {% for node in go_waku_filter_nodes %}
       --filter-node={{ node }}
 {% endfor %}
+{% else %}
+      --filter=false
 {% endif %}
-      --lightpush={{ go_waku_lightpush_enabled | bool | to_json }}
-{% if go_waku_lightpush_enabled %}
+{% if 'lightpush' in go_waku_protocols_enabled %}
+      --lightpush=true
 {% for node in go_waku_lightpush_nodes %}
       --lightpush-node={{ node }}
 {% endfor %}
+{% else %}
+      --lightpush=false
 {% endif %}
       --dns-discovery={{ go_waku_dns_disc_enabled | bool | to_json }}
 {% if go_waku_dns_disc_enabled %}


### PR DESCRIPTION
After disabling `store` protocol we have wakucanaries failing:
```
Command:
/usr/local/bin/wakucanary \
  --address=/dns4/node-01.ac-cn-hongkong-c.go-waku.test.statusim.net/tcp/30303/p2p/16Uiu2HAmBDbMWFiG9ki8sDw6fYtraSxo4oHU9HbuN43S2HVyq1FD \
  --timeout=29 \
  --node-port=20672 \
  --log-level=ERROR \
  --protocol=relay \
  --protocol=store
Return Code:
1
Stdout:
ERR 2023-11-09 14:02:02.560+00:00 Not all protocols are supported            tid=1102237 file=wakucanary.nim:188 expected="@[\"relay\", \"store\"]" supported="@[\"/floodsub/1.0.0\", \"/ipfs/id/1.0.0\", \"/ipfs/id/push/1.0.0\", \"/ipfs/ping/1.0.0\", \"/libp2p/autonat/1.0.0\", \"/libp2p/circuit/relay/0.2.0/hop\", \"/libp2p/circuit/relay/0.2.0/stop\", \"/libp2p/dcutr\", \"/meshsub/1.0.0\", \"/meshsub/1.1.0\", \"/vac/waku/filter-push/2.0.0-beta1\", \"/vac/waku/filter-subscribe/2.0.0-beta1\", \"/vac/waku/lightpush/2.0.0-beta1\", \"/vac/waku/metadata/1.0.0\", \"/vac/waku/relay/2.0.0\"]"
ERR 2023-11-09 14:02:02.560+00:00 The node has some problems (see logs)      tid=1102237 file=wakucanary.nim:202

Stderr:
```

Let's set consul meta, like we do for nim-waku:
https://github.com/status-im/infra-hq/blob/abb2d69ee9b1aa2b97ff015957ac48ee8f67be5c/ansible/roles/cabot-conf/files/cabot_consul.py#L125-L133

Also change to array of enabled protocols like we do for nim-waku